### PR TITLE
Bugfix for redirects with value 0 as query parameter

### DIFF
--- a/src/Http/UriDetector.php
+++ b/src/Http/UriDetector.php
@@ -254,7 +254,7 @@ class UriDetector
             foreach($aQueryParts as $sKey => $sValue)
             {
                 $sValue = rawurlencode($sValue);
-                $aNewQueryParts[] = rawurlencode($sKey) . ($sValue ? '=' . $sValue : $sValue);
+                $aNewQueryParts[] = rawurlencode($sKey) . (null === $sValue ? '=' . $sValue : $sValue);
             }
             return '?' . implode('&', $aNewQueryParts);
         }

--- a/tests/UriDetectorTest.php
+++ b/tests/UriDetectorTest.php
@@ -171,6 +171,12 @@ final class UriDetectorTest extends TestCase
             $this->xUriDetector->redirect('http://example.test/path?param1=value1&param2=value2', []));
     }
 
+    public function testRedirectWithValueZero()
+    {
+        $this->assertEquals('http://example.test/path?param1=0',
+            $this->xUriDetector->redirect('http://example.test/path?param1=0', []));
+    }
+
     public function testRedirectUrlWithSpecialChars()
     {
         $this->assertEquals('http://example.test/path?param1=%22value1%22&param2=%25value2%25#anchor',


### PR DESCRIPTION
If you try to redirect to an url with a query parameter value 0 it doesn't work like expected.

Given:
param1=0

Result:
param10

Expected Result:
param1=0